### PR TITLE
Apply hostname and user-data customisation at clone time

### DIFF
--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -281,6 +281,67 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 						Value: "FakeResourcePool0",
 					},
 				},
+				{
+					Name: "config.vAppConfig",
+					Val: &types.VmConfigInfo{
+						Product: []types.VAppProductInfo{
+							{
+								Key:  0,
+								Name: "Ubuntu 16.04 Server (20170815)",
+							},
+						},
+						Property: []types.VAppPropertyInfo{{
+							Key:              0,
+							Id:               "instance-id",
+							Label:            "A Unique Instance ID for this instance",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "id-ovf",
+							Value:            "",
+						}, {
+							Key:              1,
+							Id:               "hostname",
+							Label:            "hostname",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "ubuntuguest",
+							Value:            "",
+							Description:      "Specifies the hostname for the appliance",
+						}, {
+							Key:              2,
+							Id:               "seedfrom",
+							Label:            "Url to seed instance data from",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "",
+							Value:            "",
+						}, {
+							Key:              3,
+							Id:               "public-keys",
+							Label:            "ssh public keys",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "",
+							Value:            "",
+						}, {
+							Key:              4,
+							Id:               "user-data",
+							Label:            "Encoded user-data",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "",
+							Value:            "",
+						}, {
+							Key:              5,
+							Id:               "password",
+							Label:            "Default User's password",
+							Type:             "string",
+							UserConfigurable: types.NewBool(true),
+							DefaultValue:     "",
+							Value:            "",
+						}},
+					},
+				},
 			},
 		}},
 		"FakeVm1": {{
@@ -559,8 +620,8 @@ func (s *clientSuite) TestEnsureVMFolder(c *gc.C) {
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeRootFolder"),
 		retrievePropertiesStubCall("FakeDatacenter"),
-		{"CreateFolder", nil},
-		{"CreateFolder", nil},
+		{"CreateFolder", []interface{}{"foo"}},
+		{"CreateFolder", []interface{}{"bar"}},
 	})
 }
 

--- a/provider/vsphere/internal/vsphereclient/createvm.go
+++ b/provider/vsphere/internal/vsphereclient/createvm.go
@@ -404,10 +404,6 @@ func (c *Client) createImportSpec(
 	c.logger.Debugf("Creating import spec")
 	cisp := types.OvfCreateImportSpecParams{
 		EntityName: vmTemplateName(args),
-		PropertyMapping: []types.KeyValue{
-			{Key: "user-data", Value: args.UserData},
-			{Key: "hostname", Value: args.Name},
-		},
 	}
 
 	c.logger.Debugf("Fetching OVF manager")

--- a/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -114,10 +114,18 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		r.MethodCall(r, "PowerOnVM_Task")
 		res.Res = &types.PowerOnVM_TaskResponse{powerOnVMTask}
 	case *methods.CloneVM_TaskBody:
-		r.MethodCall(r, "CloneVM_Task")
+		req := req.(*methods.CloneVM_TaskBody).Req
+		specConfig := req.Spec.Config
+		var vAppConfig types.BaseVmConfigSpec
+		if specConfig != nil {
+			vAppConfig = specConfig.VAppConfig
+		}
+		r.MethodCall(r, "CloneVM_Task", vAppConfig)
 		res.Res = &types.CloneVM_TaskResponse{cloneVMTask}
 	case *methods.CreateFolderBody:
-		r.MethodCall(r, "CreateFolder")
+		req := req.(*methods.CreateFolderBody).Req
+		logger.Debugf("CreateFolder: %q", req.Name)
+		r.MethodCall(r, "CreateFolder", req.Name)
 		res.Res = &types.CreateFolderResponse{}
 	case *methods.CreateImportSpecBody:
 		req := req.(*methods.CreateImportSpecBody).Req


### PR DESCRIPTION
This means that subsequent VMs created from the template have the right details so that the agents will start.
